### PR TITLE
Add dark mode toggle with localStorage persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,25 @@
+import { useState, useEffect } from 'react'
 import './App.css'
 
 function App() {
+  const [isDark, setIsDark] = useState(() => {
+    const saved = localStorage.getItem('theme')
+    if (saved) return saved === 'dark'
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark)
+    document.documentElement.classList.toggle('light', !isDark)
+    localStorage.setItem('theme', isDark ? 'dark' : 'light')
+  }, [isDark])
+
   return (
     <div>
       <h1>Hello World</h1>
+      <button onClick={() => setIsDark(prev => !prev)}>
+        {isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+      </button>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,16 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-background: #242424;
+  --color-link: #646cff;
+  --color-link-hover: #535bf2;
+  --color-button-bg: #1a1a1a;
+  --color-button-text: rgba(255, 255, 255, 0.87);
+
+  color: var(--color-text);
+  background-color: var(--color-background);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -13,13 +21,33 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+html.light {
+  --color-text: #213547;
+  --color-background: #ffffff;
+  --color-link: #646cff;
+  --color-link-hover: #747bff;
+  --color-button-bg: #f9f9f9;
+  --color-button-text: #213547;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not(.dark):not(.light) {
+    --color-text: #213547;
+    --color-background: #ffffff;
+    --color-link: #646cff;
+    --color-link-hover: #747bff;
+    --color-button-bg: #f9f9f9;
+    --color-button-text: #213547;
+  }
+}
+
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-link);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-link-hover);
 }
 
 body {
@@ -28,6 +56,9 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 h1 {
@@ -42,27 +73,15 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-button-bg);
+  color: var(--color-button-text);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-link);
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary

- Adds a toggle button to switch between dark and light themes
- Persists user preference in `localStorage`
- Falls back to system `prefers-color-scheme` when no preference is stored
- Uses CSS custom properties for clean theming across the app
- Smooth transition on theme switch

## Test plan

- [ ] Toggle button appears on the page
- [ ] Clicking the button switches between dark and light mode
- [ ] Preference is persisted across page reloads (check `localStorage`)
- [ ] Without a saved preference, system color scheme is respected

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)