### PR TITLE
Fix dev server port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Start the development server:
 npm run dev
 ```
 
-The app will be available at `http://localhost:5173/`
+The app will be available at `http://localhost:3333/`
 
 ### Building for Production
 


### PR DESCRIPTION
## Summary
- Corrects the documented localhost port from `5173` to `3333` to match the Vite dev server configuration set in a previous commit

## Test plan
- [ ] Verify README now shows the correct port `3333`

🤖 Generated with [Claude Code](https://claude.com/claude-code)